### PR TITLE
Fixing build and more updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ pg_test = []
 
 #pgx = { git = "https://github.com/zombodb/pgx", branch = "develop" }
 #pgx-macros = { git = "https://github.com/zombodb/pgx", branch = "develop" }
-pgx = "0.4.2"
-pgx-macros = "0.4.2"
+pgx = "0.4.5"
+pgx-macros = "0.4.5"
 
 #pgx-utils = { git = "https://github.com/zombodb/pgx", branch = "develop" }
-pgx-utils = "0.4.2"
+pgx-utils = "0.4.5"
 
 [dev-dependencies]
 #pgx-tests = { git = "https://github.com/zombodb/pgx", branch = "develop" }
-pgx-tests = "0.4.2"
+pgx-tests = "0.4.5"
 
 
 [profile.dev]

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,7 +35,7 @@ echo "PGX Version: ${PGXVERSION}"
 mkdir -p ${LOGDIR}
 mkdir -p ${ARTIFACTDIR}
 
-for image in `ls docker/ | grep focal` ; do
+for image in `ls docker/ ` ; do
 
     OS_DIST=$(echo ${image}|cut -f2 -d-)
     OS_VER=$(echo ${image}|cut -f3 -d-)

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,7 +35,7 @@ echo "PGX Version: ${PGXVERSION}"
 mkdir -p ${LOGDIR}
 mkdir -p ${ARTIFACTDIR}
 
-for image in `ls docker/ | grep jammy` ; do
+for image in `ls docker/ | grep focal` ; do
 
     OS_DIST=$(echo ${image}|cut -f2 -d-)
     OS_VER=$(echo ${image}|cut -f3 -d-)

--- a/build/build.sh
+++ b/build/build.sh
@@ -21,7 +21,7 @@ BASE=$(dirname `pwd`)
 VERSION=$(cat $BASE/pgdd.control | grep default_version | cut -f2 -d\')
 LOGDIR=${BASE}/target/logs
 ARTIFACTDIR=${BASE}/target/artifacts
-PGXVERSION=0.4.2
+PGXVERSION=0.4.5
 
 PG_VERS=("pg10" "pg11" "pg12" "pg13" "pg14")
 #PG_VERS=("pg14")
@@ -35,7 +35,7 @@ echo "PGX Version: ${PGXVERSION}"
 mkdir -p ${LOGDIR}
 mkdir -p ${ARTIFACTDIR}
 
-for image in `ls docker/` ; do
+for image in `ls docker/ | grep jammy` ; do
 
     OS_DIST=$(echo ${image}|cut -f2 -d-)
     OS_VER=$(echo ${image}|cut -f3 -d-)

--- a/build/docker/pgdd-ubuntu-focal/Dockerfile
+++ b/build/docker/pgdd-ubuntu-focal/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" >> /etc/
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
-        clang-10 llvm-10 clang libz-dev strace pkg-config \
+        clang-12 llvm-12 clang libz-dev strace pkg-config \
         libxml2 libxml2-dev libreadline8 libreadline-gplv2-dev \
         flex bison libbison-dev build-essential \
         zlib1g-dev libxslt-dev libssl-dev libxml2-utils xsltproc libgss-dev \
@@ -41,21 +41,4 @@ ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
 
 RUN /bin/bash rustup.sh -y \
     && cargo install cargo-pgx --version ${PGXVERSION}
-#RUN /bin/bash rustup.sh -y \
-#    && cargo install --force --git "https://github.com/zombodb/pgx" \
-#        --branch "develop" \
-#        "cargo-pgx"
 
-
-RUN mkdir -p /home/${USER}/.pgx/data-10 \
-    && mkdir /home/${USER}/.pgx/data-11 \
-    && mkdir /home/${USER}/.pgx/data-12 \
-    && mkdir /home/${USER}/.pgx/data-13 \
-    && mkdir /home/${USER}/.pgx/data-14
-
-RUN cargo pgx init \
-    --pg10=/usr/lib/postgresql/10/bin/pg_config \
-    --pg11=/usr/lib/postgresql/11/bin/pg_config \
-    --pg12=/usr/lib/postgresql/12/bin/pg_config \
-    --pg13=/usr/lib/postgresql/13/bin/pg_config \
-    --pg14=/usr/lib/postgresql/14/bin/pg_config

--- a/build/docker/pgdd-ubuntu-focal/Dockerfile
+++ b/build/docker/pgdd-ubuntu-focal/Dockerfile
@@ -14,8 +14,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y make wget curl gnupg git
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" >> /etc/apt/sources.list.d/pgdg.list \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y \
+RUN apt-get update && apt-get upgrade -y --fix-missing
+RUN apt-get install -y --fix-missing \
         clang-12 llvm-12 clang libz-dev strace pkg-config \
         libxml2 libxml2-dev libreadline8 libreadline-gplv2-dev \
         flex bison libbison-dev build-essential \

--- a/build/docker/pgdd-ubuntu-focal/Dockerfile
+++ b/build/docker/pgdd-ubuntu-focal/Dockerfile
@@ -11,9 +11,11 @@ RUN useradd -m ${USER} --uid=${UID}
 
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y && apt-get install -y make wget curl gnupg git
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" >> /etc/apt/sources.list.d/pgdg.list \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y make wget curl gnupg git postgresql-common
+
+RUN sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+
 RUN apt-get update && apt-get upgrade -y --fix-missing
 RUN apt-get install -y --fix-missing \
         clang-12 llvm-12 clang libz-dev strace pkg-config \

--- a/build/docker/pgdd-ubuntu-jammy/Dockerfile
+++ b/build/docker/pgdd-ubuntu-jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:impish
+FROM ubuntu:jammy
 
 LABEL maintainer="PgDD Project - https://github.com/rustprooflabs/pgdd"
 
@@ -12,11 +12,11 @@ RUN useradd -m ${USER} --uid=${UID}
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y make wget curl gnupg git
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ impish-pgdg main" >> /etc/apt/sources.list.d/pgdg.list \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" >> /etc/apt/sources.list.d/pgdg.list \
     &&  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 RUN apt-get update && apt-get upgrade -y --fix-missing
 RUN apt-get install -y --fix-missing \
-        clang-13 llvm-13 clang libz-dev strace pkg-config \
+        clang-14 llvm-14 clang libz-dev strace pkg-config \
         libxml2 libxml2-dev libreadline8 libreadline-dev \
         flex bison libbison-dev build-essential \
         zlib1g-dev libxslt-dev libssl-dev libxml2-utils xsltproc libgss-dev \
@@ -42,17 +42,3 @@ ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
 
 RUN /bin/bash rustup.sh -y \
     && cargo install cargo-pgx --version ${PGXVERSION}
-
-
-RUN mkdir -p /home/${USER}/.pgx/data-10 \
-    && mkdir /home/${USER}/.pgx/data-11 \
-    && mkdir /home/${USER}/.pgx/data-12 \
-    && mkdir /home/${USER}/.pgx/data-13 \
-    && mkdir /home/${USER}/.pgx/data-14
-
-RUN cargo pgx init \
-    --pg10=/usr/lib/postgresql/10/bin/pg_config \
-    --pg11=/usr/lib/postgresql/11/bin/pg_config \
-    --pg12=/usr/lib/postgresql/12/bin/pg_config \
-    --pg13=/usr/lib/postgresql/13/bin/pg_config \
-    --pg14=/usr/lib/postgresql/14/bin/pg_config

--- a/build/docker/pgdd-ubuntu-jammy/Dockerfile
+++ b/build/docker/pgdd-ubuntu-jammy/Dockerfile
@@ -11,9 +11,11 @@ RUN useradd -m ${USER} --uid=${UID}
 
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y && apt-get install -y make wget curl gnupg git
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" >> /etc/apt/sources.list.d/pgdg.list \
-    &&  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y make wget curl gnupg git postgresql-common
+
+RUN sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+
 RUN apt-get update && apt-get upgrade -y --fix-missing
 RUN apt-get install -y --fix-missing \
         clang-14 llvm-14 clang libz-dev strace pkg-config \

--- a/build/package.sh
+++ b/build/package.sh
@@ -27,6 +27,9 @@ fi
 
 PKG_FORMAT=deb
 
+echo "    Running pgx init for ${PG_VER}"
+$(cargo pgx init --${PG_VER} download)
+
 echo "Changing to build dir..."
 cd /build
 

--- a/build/package.sh
+++ b/build/package.sh
@@ -58,6 +58,8 @@ find ./ -name "*.so" -exec strip {} \;
 #
 OUTNAME=pgdd_${VERSION}_${OSNAME}_${PG_VER}_amd64
 if [ "${PKG_FORMAT}" == "deb" ]; then
+	rm ${OUTNAME}.deb || true
+
 	fpm \
 		-s dir \
 		-t deb \


### PR DESCRIPTION
Build via Docker had been failing, working to fix that, bumping version to latest while I'm at it.

Updating from pgx 0.4.2 to 0.4.5. Update latest Ubuntu to Jammy (22.04) LTS, edits for testing.  Build on Focal currently fails missing glibc

* [x] Get build working on focal
* [x] Get build working on jammy