### PR TITLE
Bump pgrx version - Checks against soundness issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgdd"
-version = "0.5.0"
+version = "0.5.1-dev"
 edition = "2018"
 description = "In-database (PostgreSQL) data dictionary providing database introspection via standard SQL query syntax."
 
@@ -17,12 +17,12 @@ pg15 = ["pgrx/pg15"]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.5"
-pgrx-macros = "=0.9.5"
+pgrx = "=0.9.8"
+pgrx-macros = "=0.9.8"
 
 
 [dev-dependencies]
-pgrx-tests = "=0.9.5"
+pgrx-tests = "=0.9.8"
 
 
 [profile.dev]

--- a/build/build.sh
+++ b/build/build.sh
@@ -21,7 +21,7 @@ BASE=$(dirname `pwd`)
 VERSION=$(cat $BASE/pgdd.control | grep default_version | cut -f2 -d\')
 LOGDIR=${BASE}/target/logs
 ARTIFACTDIR=${BASE}/target/artifacts
-PGRXVERSION=0.9.5
+PGRXVERSION=0.9.8
 
 PG_VERS=("pg11" "pg12" "pg13" "pg14" "pg15")
 #PG_VERS=("pg15")

--- a/pgdd.control
+++ b/pgdd.control
@@ -1,5 +1,5 @@
 comment = 'An in-database data dictionary providing database introspection via standard SQL query syntax.  Developed using pgx (https://github.com/zombodb/pgx).'
-default_version = '0.5.0'
+default_version = '0.5.1-dev'
 module_pathname = '$libdir/pgdd'
 relocatable = false
 schema = dd


### PR DESCRIPTION
Bump pgrx version to ensure this wasn't affected by Spi soundness issues fixed by [pgrx 0.9.8](https://github.com/pgcentralfoundation/pgrx/releases/tag/v0.9.8)

