### PR TITLE
OS Support improvements

### DIFF
--- a/ADVANCED-INSTALL.md
+++ b/ADVANCED-INSTALL.md
@@ -1,23 +1,88 @@
 # PgDD Advanced installation
 
-This page covers installing PgDD from source locally, and the Docker build
-method based on [ZomboDB's build system](https://github.com/zombodb/zombodb)
-used to create the binaries for multiple versions.
+This page covers two methods that can be used to build binary installers
+for PgDD.
+The two methods that can be used to build binaries are the Docker build system
+and manually installing `pgrx` on the target OS and architecture.
+Installers are specific to three (3) details:
+
+* CPU Architecture
+* Operating System version
+* Postgres version
 
 
-## Create Binary installer for your system
+The Docker build method uses OS specific `Dockerfile` to provide one binary
+installer for each supported Postgres version.  This is the best approach
+when the appropriate `Dockerfile` already exists.
+
+
+## Use Docker to build binary packages
+
+The Docker build method was originally based on
+[ZomboDB's build system](https://github.com/zombodb/zombodb) and has
+evolved with this project since then.
+
+To generate the full suite of binaries change into the `./build` directory
+and run `build.sh`.  This currently creates 15 total binary installers for
+3 different OSs (Postgres 12 - 16).
+
+```bash
+cd build/
+time bash ./build.sh
+```
+
+Individual installers can be found under `./target/artifacts`.  A package of
+all installers is saved to `./build/pgdd-binaries.tar.gz`.
+
+> Tagged versions of PgDD include LTS OS binaries with their [release notes](https://github.com/rustprooflabs/pgdd/releases).
+
+
+### Customize Docker Build system
+
+The Docker build system can be adjusted locally to build a binary for
+a specific Postgres version and/or specific OS.
+
+The `./build/build.sh` script has the logic to be adjusted to control this.
+The Postgres versions can be  altered manually by commenting out the line
+with all versions and uncommenting the line with a specific Postgres version.
+The two lines in the script are shown below.
+
+```bash
+PG_VERS=("pg12" "pg13" "pg14" "pg15" "pg16")
+#PG_VERS=("pg16")
+```
+
+
+To only build for Postgres on a single OS, add a `grep <osname` command to the
+loop logic.  The original file that runs for all OSs with Dockerfiles looks like
+the following line.
+
+```bash
+for image in `ls docker/ ` ; do
+```
+
+To build for only `lunar` (Ubuntu 23.04) add ` | grep lunar ` as shown in the
+following example.
+
+```bash
+for image in `ls docker/ | grep lunar ` ; do
+```
+
+
+## Create Binary Installer w/out Docker
 
 The following steps walk through creating a package on a typical
-Ubuntu based system with Postgres 15.
+Ubuntu based system with Postgres 15.  These manual instructions can be used
+when you do not want to use the Docker based build system under `./build/`.
 
 
-### Prereqs
+### Prerequisites
 
-pgrx and its dependencies are the main prereq for PgDD.
-Install Prereqs and ensure PostgreSQL dev tools are installed.
+The main perquisites for PgDD are `pgrx` and its dependencies.
+Install prereqs and ensure PostgreSQL dev tools are installed.
 
-> See the [Cargo pgrx](https://github.com/tcdi/pgrx/tree/master/cargo-pgrx)
-documentation for more information on using pgrx.
+> See the [cargo pgrx](https://github.com/pgcentralfoundation/pgrx/tree/master/cargo-pgrx)
+documentation for more information on using `pgrx`.
 
 
 ```bash
@@ -48,7 +113,7 @@ cargo install cargo-deb
 ```
 
 
-Initialize pgrx.  Need to run this after install AND occasionally to get updates
+Initialize `pgrx`.  Need to run this after install AND occasionally to get updates
 to Postgres versions or glibc updates.  Not typically required to follow pgrx
 developments.
 
@@ -101,42 +166,6 @@ sudo dpkg -i --force-overwrite ./pgdd.deb
 
 
 
-## Use Docker to build binary packages
-
-Ubuntu 22.04 (Jammy) binaries are available for 0.5.1 for Postgres 12
-through Postgres 16.
-
-
-```bash
-cd build/
-time bash ./build.sh
-```
-
-Tagged versions will be attached to their [releases](https://github.com/rustprooflabs/pgdd/releases).
-
-### Specific Postgres version and OS
-
-The `./build.sh` is setup to loop through all supported Postgres versions and OSs.
-
-The Postgres version behavior can be altered manually by commenting out the line
-with all versions and uncommenting the line with a specific Postgres version:
-
-```bash
-PG_VERS=("pg12" "pg13" "pg14" "pg15" "pg16")
-#PG_VERS=("pg16")
-```
-
-To limit to a single OS change this line:
-
-```bash
-for image in `ls docker/ ` ; do
-```
-
-To `grep <osname>` to limit.
-
-```bash
-for image in `ls docker/ | grep lunar ` ; do
-```
 
 ## pgrx Generate graphviz
 

--- a/ADVANCED-INSTALL.md
+++ b/ADVANCED-INSTALL.md
@@ -103,8 +103,8 @@ sudo dpkg -i --force-overwrite ./pgdd.deb
 
 ## Use Docker to build binary packages
 
-Ubuntu 22.04 (Jammy) binaries are available for 0.5.0 for Postgres 11
-through Postgres 15.
+Ubuntu 22.04 (Jammy) binaries are available for 0.5.1 for Postgres 12
+through Postgres 16.
 
 
 ```bash
@@ -114,6 +114,29 @@ time bash ./build.sh
 
 Tagged versions will be attached to their [releases](https://github.com/rustprooflabs/pgdd/releases).
 
+### Specific Postgres version and OS
+
+The `./build.sh` is setup to loop through all supported Postgres versions and OSs.
+
+The Postgres version behavior can be altered manually by commenting out the line
+with all versions and uncommenting the line with a specific Postgres version:
+
+```bash
+PG_VERS=("pg12" "pg13" "pg14" "pg15" "pg16")
+#PG_VERS=("pg16")
+```
+
+To limit to a single OS change this line:
+
+```bash
+for image in `ls docker/ ` ; do
+```
+
+To `grep <osname>` to limit.
+
+```bash
+for image in `ls docker/ | grep lunar ` ; do
+```
 
 ## pgrx Generate graphviz
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ pg16 = ["pgrx/pg16"]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.1"
-pgrx-macros = "=0.10.1"
+pgrx = "=0.10.2"
+pgrx-macros = "=0.10.2"
 
 
 [dev-dependencies]
-pgrx-tests = "=0.10.1"
+pgrx-tests = "=0.10.2"
 
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ PgDD has been tested to work for PostgreSQL 12 through 16.
 
 ## Install from binary
 
-Binaries are available for Ubuntu 22.04 (jammy) for AMD 64 architectures.
-See [releases](https://github.com/rustprooflabs/pgdd/releases) for the full list of binaries.
+Binaries for supported Postgres versions are made available for each release.
+See the individual release from the [releases](https://github.com/rustprooflabs/pgdd/releases)
+page for the full list of binaries.
+This includes binaries for two main LTS supported OS's using the AMD64 architecture.
+The latest Ubuntu LTS (currently Jammy, 22.04) and the "PostGIS" image
+(currently Debian 11).  The PostGIS image is provided to allow inclusion
+in the [PgOSM Flex](https://pgosm-flex.com) project's Docker image. 
 
 Download and install for Postgres 16 on Ubuntu 22.04.
 
@@ -46,6 +51,20 @@ SELECT extname, extversion
 │ pgdd    │ 0.5.0      │
 └─────────┴────────────┘
 ```
+
+
+## Non-LTS OS Support
+
+Interim Ubuntu OS versions, such as 23.04, may have minimal support
+through the inclusion of a `Dockerfile` under
+[`./build/docker/`](https://github.com/rustprooflabs/pgdd/tree/main/build/docker).
+The intent with these is to prepare for potential changes in the upcoming LTS
+version, e.g. 24.04.
+
+Binaries will not be provided for these interim OS's.  To get the binary for
+one of these releases follow the instructions in the
+[Advanced Installation](./ADVANCED-INSTALL.md) section, under
+[the Docker section](ADVANCED-INSTALL.md#use-docker-to-build-binary-packages).
 
 
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -21,7 +21,7 @@ BASE=$(dirname `pwd`)
 VERSION=$(cat $BASE/pgdd.control | grep default_version | cut -f2 -d\')
 LOGDIR=${BASE}/target/logs
 ARTIFACTDIR=${BASE}/target/artifacts
-PGRXVERSION=0.10.1
+PGRXVERSION=0.10.2
 
 PG_VERS=("pg12" "pg13" "pg14" "pg15" "pg16")
 #PG_VERS=("pg16")

--- a/build/docker/pgdd-ubuntu-lunar/Dockerfile
+++ b/build/docker/pgdd-ubuntu-lunar/Dockerfile
@@ -1,0 +1,49 @@
+# Ubuntu Lunar is an intermediate release of Ubuntu, not an LTS version.
+# Non-LTS veresion are minimally supported until the next LTS version is released.
+FROM ubuntu:lunar
+
+LABEL maintainer="PgDD Project - https://github.com/rustprooflabs/pgdd"
+
+ARG USER=ubuntu
+ARG UID=1000
+ARG GID=1000
+ARG PGRXVERSION
+
+# Ubuntu Lunar (23.04) has the ubuntu user as ID 1000. Why now when not in jmmay?
+#RUN useradd -m ${USER} --uid=${UID}
+
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y make wget curl gnupg git postgresql-common
+
+RUN sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+
+RUN apt-get update && apt-get upgrade -y --fix-missing
+RUN apt-get install -y --fix-missing \
+        clang-14 llvm-14 clang libz-dev strace pkg-config \
+        libxml2 libxml2-dev libreadline8 libreadline-dev \
+        flex bison libbison-dev build-essential \
+        zlib1g-dev libxslt-dev libssl-dev libxml2-utils xsltproc libgss-dev \
+        libldap-dev libkrb5-dev gettext tcl-tclreadline tcl-dev libperl-dev \
+        libpython3-dev libprotobuf-c-dev libprotobuf-dev gcc \
+        ruby ruby-dev rubygems \
+        postgresql-12 postgresql-server-dev-12 \
+        postgresql-13 postgresql-server-dev-13 \
+        postgresql-14 postgresql-server-dev-14 \
+        postgresql-15 postgresql-server-dev-15 \
+        postgresql-16 postgresql-server-dev-16 \
+    && apt autoremove -y
+
+
+RUN gem install --no-document fpm
+
+
+USER ${UID}:${GID}
+WORKDIR /home/${USER}
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
+
+RUN /bin/bash rustup.sh -y \
+    && cargo install --locked cargo-pgrx --version ${PGRXVERSION}


### PR DESCRIPTION
RE #43

This adds a Dockerfile for Ubuntu 23.04 and improves docs around OS versions. Bumping pgrx to [0.10.2](https://github.com/pgcentralfoundation/pgrx/releases/tag/v0.10.2) should fix issues if anyone is trying to build for Postgres 16 on MacOS.

I haven't tested the binaries generated by the new `lunar` Dockerfile since I haven't upgraded anything to 23.04 yet.  They should work though.  The documentation improvements should make it easier for others to to use the `./build/build.sh` process to build/test binaries for their OS / architecture.  

Edit: <del>Docs are still generally rough, I'll try to polish those up in coming weeks.</del> I rearranged the advanced-install section and tried to provide guidance on how to build custom binaries not provided through the official release.

