### PR TITLE
Fix Postgres 16 build

### DIFF
--- a/build/docker/pgdd-ubuntu-jammy/Dockerfile
+++ b/build/docker/pgdd-ubuntu-jammy/Dockerfile
@@ -11,6 +11,7 @@ RUN useradd -m ${USER} --uid=${UID}
 
 
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y make wget curl gnupg git postgresql-common
 
@@ -18,10 +19,11 @@ RUN sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
 
 RUN apt-get update && apt-get upgrade -y --fix-missing
 RUN apt-get install -y --fix-missing \
-        clang-14 llvm-14 clang libz-dev strace pkg-config \
+        clang libz-dev strace pkg-config \
         libxml2 libxml2-dev libreadline8 libreadline-dev \
         flex bison libbison-dev build-essential \
-        zlib1g-dev libxslt-dev libssl-dev libxml2-utils xsltproc libgss-dev \
+        zlib1g-dev libxslt-dev libssl-dev \
+        libxml2-utils xsltproc libgss-dev \
         libldap-dev libkrb5-dev gettext tcl-tclreadline tcl-dev libperl-dev \
         libpython3-dev libprotobuf-c-dev libprotobuf-dev gcc \
         ruby ruby-dev rubygems \

--- a/build/package.sh
+++ b/build/package.sh
@@ -45,6 +45,10 @@ echo "PgDD Building for:  ${OSNAME}-${VERSION}"
 PG_CONFIG_DIR=$(dirname $(grep ${PG_VER} ~/.pgrx/config.toml | cut -f2 -d= | cut -f2 -d\"))
 export PATH=${PG_CONFIG_DIR}:${PATH}
 
+# Jubilee's suggestion fixed the issue:
+#  https://github.com/pgcentralfoundation/pgrx/issues/1298#issuecomment-1806688762
+export PGRX_BINDGEN_NO_DETECT_INCLUDES=please
+
 echo "   Packaging pgrx"
 cargo pgrx package || exit $?
 


### PR DESCRIPTION
Fix Postgres 16 build failing RE multiple clang/llvm. The suggestion that seemed to be the fix was setting `PGRX_BINDGEN_NO_DETECT_INCLUDES=please` from here: https://github.com/pgcentralfoundation/pgrx/issues/1298#issuecomment-1806688762

I tried the changes from pgrx's CI fixes (see https://github.com/pgcentralfoundation/pgrx/pull/1326) but those didn't seem to have any effect in my troubleshooting.